### PR TITLE
Define branch PHP5 of the project pthreads

### DIFF
--- a/shell/bootstrap_ubuntu.sh
+++ b/shell/bootstrap_ubuntu.sh
@@ -34,7 +34,7 @@ then
 
   #Download pthreads
   cd ext
-  git clone --depth 1 https://github.com/krakjoe/pthreads
+  git clone --depth 1 --branch PHP5 https://github.com/krakjoe/pthreads
   cd ../
 
   #NEED THIS (check README)


### PR DESCRIPTION
The branch master of the pthreads project is in version PHP7. =]
